### PR TITLE
【修复，前端】优化网页标题逻辑

### DIFF
--- a/src/main/resources/templates/fragments/head.html
+++ b/src/main/resources/templates/fragments/head.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org" xmlns:sec="http://www.thymeleaf.org/extras/spring-security6">
-<head th:fragment="head(title='期末大作业商城')">
+<head th:fragment="head(title)">
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title th:text="${title} ?: '期末大作业商城'">期末大作业商城</title>
+  <title th:text="${title}">期末大作业商城</title>
   
   <!-- 全局样式 -->
   <link rel="stylesheet" th:href="@{/css/main.css}">

--- a/src/main/resources/templates/product-detail.html
+++ b/src/main/resources/templates/product-detail.html
@@ -1,8 +1,7 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org">
 
-<head th:replace="~{fragments/head :: head('商品详情')}">
-  <title>商品详情</title>
+<head th:replace="~{fragments/head :: head(${product.name + ' - 商品详情'})}">
 </head>
 
 <body>


### PR DESCRIPTION
- 修改 head.html 中的标题逻辑，使用传入的 title 参数作为网页标题
- 更新 product-detail.html 中的标题传递方式，动态显示商品名称